### PR TITLE
test: ci build

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -26,13 +26,13 @@ variables:
   image: docker:24.0.5
   services:
     - name: docker:24.0.5-dind
-      command: ["--insecure-registry=172.100.100.8:5050", "--insecure-registry=172.100.100.9:5050"]
+      command: ["--insecure-registry=192.168.5.9:5050"]
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""
   before_script:
     - mkdir -p /etc/docker
-    - echo '{"insecure-registries":["172.100.100.8:5050","172.100.100.9:5050"]}' > /etc/docker/daemon.json
+    - echo '{"insecure-registries":["192.168.5.9:5050"]}' > /etc/docker/daemon.json
     - docker login -u $CI_REGISTRY_USER -p $CI_REGISTRY_PASSWORD $CI_REGISTRY
   only:
     refs:

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -12,7 +12,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY . .
 
 # Expose port
-EXPOSE 3001
+EXPOSE 3001 
 
 # Run the app 
 CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "3001"]

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -28,4 +28,4 @@ COPY --from=builder /app/dist /usr/share/nginx/html
 # Expose port 80 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx", "-g", "daemon off;"]  


### PR DESCRIPTION
### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Update Docker registry configuration to use single IP address
  - Changed insecure registry from dual IPs to single 192.168.5.9:5050
  - Updated daemon.json configuration accordingly

- Minor whitespace formatting adjustments in Dockerfiles


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["GitLab CI Config"] -- "Update registry IPs" --> B["Single Registry 192.168.5.9:5050"]
  C["Backend Dockerfile"] -- "Whitespace fix" --> D["Formatting cleanup"]
  E["Frontend Dockerfile"] -- "Whitespace fix" --> D
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>.gitlab-ci.yml</strong><dd><code>Consolidate Docker registry to single IP address</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.gitlab-ci.yml

<ul><li>Updated Docker service insecure registry from dual IPs <br>(172.100.100.8:5050, 172.100.100.9:5050) to single IP <br>(192.168.5.9:5050)<br> <li> Updated daemon.json configuration to reflect single registry endpoint<br> <li> Simplified registry configuration for Docker build template</ul>


</details>


  </td>
  <td><a href="https://github.com/SteelCrab/gition/pull/105/files#diff-037ea159eb0a7cb0ac23b851e66bee30fb838ee8d0d99fa331a1ba65283d37f7">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Minor whitespace formatting adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/Dockerfile

- Added trailing whitespace after EXPOSE 3001 port declaration


</details>


  </td>
  <td><a href="https://github.com/SteelCrab/gition/pull/105/files#diff-fed51f49a9f26cb93cc870efdc9419d425b9422354ae41bb651c3333c8bff486">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Minor whitespace formatting adjustment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/Dockerfile

- Added trailing whitespace after CMD instruction


</details>


  </td>
  <td><a href="https://github.com/SteelCrab/gition/pull/105/files#diff-ea60ef29f6f537c1c83468c00b60de28f86e06edfe4a3d91274723c6f298fdb8">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Consolidated Docker registry configuration to use a single private registry endpoint (192.168.5.9:5050) across container build processes
  * Applied minor whitespace and formatting updates to Dockerfile configurations for consistency

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->