### PR TITLE
fix: use FRONTEND_URL for OAuth redirect URI

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -125,7 +125,7 @@ async def github_auth():
         - repo: Access public/private repositories (important!)
     """
     # Nginx proxies to port 80, so callback URL uses port 80
-    redirect_uri = "http://localhost/auth/github/callback"
+    redirect_uri = f"{FRONTEND_URL}/auth/github/callback"
     
     # 'repo' scope grants access to private repositories
     scope = "read:user user:email repo"


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Replace hardcoded localhost redirect URI with FRONTEND_URL environment variable

- Enables OAuth callback to work in production and non-localhost environments


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded localhost URI"] -- "replaced with" --> B["FRONTEND_URL environment variable"]
  B -- "enables" --> C["Production OAuth support"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.py</strong><dd><code>Replace hardcoded localhost with FRONTEND_URL</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/main.py

<ul><li>Replace hardcoded <code>http://localhost/auth/github/callback</code> with dynamic <br><code>f"{FRONTEND_URL}/auth/github/callback"</code><br> <li> Allows OAuth redirect URI to adapt to different deployment <br>environments<br> <li> Fixes OAuth authentication in production deployments</ul>


</details>


  </td>
  <td><a href="https://github.com/SteelCrab/gition/pull/111/files#diff-df5184bf1f67239fcedd4578cd15b7c94f3f765feabd09c5f20b5831bca33903">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GitHub OAuth redirect URL to dynamically use the frontend URL instead of a hardcoded localhost address, enabling authentication to work correctly across different deployment environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->